### PR TITLE
Partially fixing persistence, highlighting what else needs to be done before completion

### DIFF
--- a/lib/postcss-persistent-filter.js
+++ b/lib/postcss-persistent-filter.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var path = require('path');
 var postcss = require('postcss');
 var Filter = require('broccoli-persistent-filter');
 
@@ -22,6 +23,21 @@ PostCSS.prototype = Object.create(Filter.prototype);
 PostCSS.prototype.constructor = PostCSS;
 PostCSS.prototype.extensions = ['css']
 PostCSS.prototype.targetExtension = 'css'
+
+PostCSS.prototype.cacheKeyProcessString = function cacheKeyProcessString(string, relativePath) {
+  /*
+   * TODO: you'll want to make sure that changing the options hash (plugins)
+   * invalidates the cache.  For example, user adds a new plugin or changes an option of
+   * a plugin than cache needs to be invalidated.
+   *
+   * You also want to invalidate the cache if the dep changes between builds (i.e., version bump of plugin)
+   */
+  return Filter.prototype.cacheKeyProcessString.apply(this, arguments);
+};
+
+PostCSS.prototype.baseDir = function baseDir() {
+  return path.join(__dirname, '..');
+};
 
 PostCSS.prototype.processString = function processString(content, relativeFile) {
   return this._processor.process(content, {

--- a/lib/postcss-persistent-filter.js
+++ b/lib/postcss-persistent-filter.js
@@ -8,8 +8,7 @@ function PostCSS(inputNode, options) {
   this._options = options || {};
 
   Filter.call(this, inputNode, {
-    annotation: this._options.annotation,
-    persist: this._options.hasOwnProperty('persist') ? this._options.persist : true
+    annotation: this._options.annotation
   });
 
   if (!Array.isArray(this._options.plugins)) {
@@ -22,22 +21,7 @@ function PostCSS(inputNode, options) {
 PostCSS.prototype = Object.create(Filter.prototype);
 PostCSS.prototype.constructor = PostCSS;
 PostCSS.prototype.extensions = ['css']
-PostCSS.prototype.targetExtension = 'css'
-
-PostCSS.prototype.cacheKeyProcessString = function cacheKeyProcessString(string, relativePath) {
-  /*
-   * TODO: you'll want to make sure that changing the options hash (plugins)
-   * invalidates the cache.  For example, user adds a new plugin or changes an option of
-   * a plugin than cache needs to be invalidated.
-   *
-   * You also want to invalidate the cache if the dep changes between builds (i.e., version bump of plugin)
-   */
-  return Filter.prototype.cacheKeyProcessString.apply(this, arguments);
-};
-
-PostCSS.prototype.baseDir = function baseDir() {
-  return path.join(__dirname, '..');
-};
+PostCSS.prototype.targetExtension = 'css';
 
 PostCSS.prototype.processString = function processString(content, relativeFile) {
   return this._processor.process(content, {

--- a/lib/postcss-persistent-filter.js
+++ b/lib/postcss-persistent-filter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var path = require('path');
 var postcss = require('postcss');
 var Filter = require('broccoli-persistent-filter');
 


### PR DESCRIPTION
Removing persistence as it cannot be done reliably here as far as I can tell.  It's hard to get right, and more hazardous to cache when it cannot be reliably invalidated in every scenario.  Less so than files changing, more so around dependencies or plugin options changing.

This is likely why many of the broccoli-persistence-filter plugins don't attempt it and the ones I've seen that do.. tend to have hard-to-reproduce issues because of it.

If we were the ones instantiating the postcss plugins then I think it /might/ be achievable (i.e., going back to module/options), but we're dealing with instances of the plugins that we cannot really hash on (plugin deps changing, options for plugin changing, and probably other scenarios such as plugins who have state stored somewhere else that might change between builds but we're obviously unaware..).

A better approach, perhaps in the future, might be to expose `persist`, `baseDir`, and  `cacheKeyProcessString` so ambitious project owners can take on the risks (like us :)).

TL;DR; too risky, hard to get "right", and not needed right now.